### PR TITLE
link-grid margin fix

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6914,7 +6914,7 @@ td.jobs-listing__date {
   -webkit-flex-direction: column;
       -ms-flex-direction: column;
           flex-direction: column;
-  margin: 0 -20px;
+  margin: 0 -1em;
 }
 
 @media (min-width: 48em) {
@@ -6933,7 +6933,7 @@ td.jobs-listing__date {
   -webkit-flex-grow: 1;
       -ms-flex-positive: 1;
           flex-grow: 1;
-  margin: 20px 0;
+  margin: 1em 0;
   padding: 0 17px;
 }
 

--- a/sass/components/_link-grid.scss
+++ b/sass/components/_link-grid.scss
@@ -8,7 +8,7 @@
 .link-grid {
   display: flex;
   flex-direction: column;
-  margin: 0 -20px;
+  margin: 0 -1em;
 
   @include breakpoint($small) {
     flex-direction: row;
@@ -19,7 +19,7 @@
 .link-grid__item {
   color: $black;
   flex-grow: 1;
-  margin: 20px 0;
+  margin: 1em 0;
   padding: 0 17px;
 
   &:hover {


### PR DESCRIPTION
Fixed: on mobile the negative margin of link-grid caused the viewport to go overwide.