### PR TITLE
Center hero big content vertically also on narrower layouts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4477,8 +4477,8 @@ dl, ol, ul {
  description:
 */
 .hero-big {
-  -ms-flex-align: end;
-      align-items: flex-end;
+  -ms-flex-align: center;
+      align-items: center;
   background-position-x: 50%;
   background-size: cover;
   display: -ms-flexbox;
@@ -4521,12 +4521,6 @@ dl, ol, ul {
   position: relative;
   z-index: 10;
   width: 100%;
-}
-
-@media (min-width: 48em) {
-  .hero-big__top {
-    margin-bottom: 9em;
-  }
 }
 
 .hero-big__content {
@@ -5628,7 +5622,7 @@ td.jobs-listing__date {
       flex-wrap: wrap;
   margin-left: auto;
   margin-right: auto;
-  max-width: 1700px;
+  max-width: 105em;
 }
 
 @media (min-width: 48em) {

--- a/sass/components/_hero.scss
+++ b/sass/components/_hero.scss
@@ -39,7 +39,7 @@
  description:
 */
 .hero-big {
-  align-items: flex-end;
+  align-items: center;
   background-position-x: 50%;
   background-size: cover;
   display: flex;
@@ -79,10 +79,6 @@
   position: relative;
   z-index: 10;
   width: 100%;
-
-  @include breakpoint($small) {
-    margin-bottom: 9em;
-  }
 }
 
 .hero-big__content {


### PR DESCRIPTION
## Description
- Changes hero big component to have content always vertically centered (was aligned to the bottom on breakpoint below 768px).

## How to test
1. Run ```gulp serve``` in styleguide root directory.
2. Open http://localhost:3000/#section-16-1-2.
3. Verify hero content is vertically entered below and over 768px breakpoint.

## Screenshots

![1](https://user-images.githubusercontent.com/3032567/37813890-11721b92-2e70-11e8-9136-8ec800852efc.jpg)

![2](https://user-images.githubusercontent.com/3032567/37813901-14f16ade-2e70-11e8-9c36-7ff509677d2e.jpg)
