### PR TITLE
Highlight and liftup grid improvements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4886,29 +4886,14 @@ dl, ol, ul {
   position: relative;
 }
 
-.highlight:after {
-  background: black;
-  bottom: 0;
-  content: "";
-  left: 0;
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  transform: translate3d(0, 0, 0);
-  transition-duration: 0.2s;
-  transition-property: opacity;
-  z-index: 1;
-}
-
-.highlight:hover:after {
-  opacity: 0.2;
-}
-
 @media (min-width: 48em) {
   .highlight {
     min-height: 480px;
   }
+}
+
+.highlight:hover .highlight__title {
+  text-decoration: underline;
 }
 
 .highlight__content {
@@ -4950,7 +4935,6 @@ dl, ol, ul {
 }
 
 .highlight__bgoverlay {
-  opacity: 0.7;
   position: absolute;
   left: 0;
   top: 0;
@@ -4960,10 +4944,17 @@ dl, ol, ul {
   background-size: cover;
 }
 
-@media (min-width: 48em) {
-  .highlight__bgoverlay {
-    opacity: 0.8;
-  }
+.highlight__bgoverlay:after {
+  background-color: black;
+  bottom: 0;
+  content: "";
+  left: 0;
+  opacity: .4;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: translate3d(0, 0, 0);
+  z-index: 1;
 }
 
 /*
@@ -5628,7 +5619,7 @@ td.jobs-listing__date {
       flex-wrap: wrap;
   margin-left: auto;
   margin-right: auto;
-  max-width: 1700px;
+  max-width: 105em;
 }
 
 @media (min-width: 48em) {

--- a/css/styles.css
+++ b/css/styles.css
@@ -4892,7 +4892,7 @@ dl, ol, ul {
   }
 }
 
-.highlight:hover .highlight__title {
+a.highlight:hover .highlight__title {
   text-decoration: underline;
 }
 
@@ -5495,10 +5495,6 @@ td.jobs-listing__date {
   position: relative;
 }
 
-.liftup-grid__item:hover .liftup-grid__title {
-  text-decoration: underline;
-}
-
 @media (min-width: 48em) {
   .liftup-grid__item {
     -ms-flex-preferred-size: 34%;
@@ -5527,6 +5523,10 @@ td.jobs-listing__date {
       align-self: flex-start;
   margin: 0 auto;
   padding-right: 6em;
+}
+
+a.liftup-grid__item:hover .liftup-grid__title {
+  text-decoration: underline;
 }
 
 .liftup-grid__content {

--- a/css/styles.css
+++ b/css/styles.css
@@ -4907,7 +4907,6 @@ a.highlight:hover .highlight__title {
 
 .highlight__title {
   font-size: 5rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   font-weight: 700;
   line-height: 1;
@@ -4929,7 +4928,6 @@ a.highlight:hover .highlight__title {
 
 .highlight__ingress {
   font-size: 1.125rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   max-width: 720px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -5495,6 +5495,10 @@ td.jobs-listing__date {
   position: relative;
 }
 
+.liftup-grid__item:hover .liftup-grid__title {
+  text-decoration: underline;
+}
+
 @media (min-width: 48em) {
   .liftup-grid__item {
     -ms-flex-preferred-size: 34%;
@@ -5504,24 +5508,6 @@ td.jobs-listing__date {
     padding: 3vw;
     width: 34%;
   }
-}
-
-.liftup-grid__item:before {
-  background-color: #000;
-  bottom: 0;
-  content: "";
-  left: 0;
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  transform: translate3d(0, 0, 0);
-  transition: opacity 0.2s;
-  z-index: 1;
-}
-
-.liftup-grid__item:hover:before {
-  opacity: 0.2;
 }
 
 .liftup-grid__item.theme-small {
@@ -5598,10 +5584,22 @@ td.jobs-listing__date {
   z-index: 0;
 }
 
+.liftup-grid__image:after {
+  background-color: #000;
+  bottom: 0;
+  content: "";
+  left: 0;
+  opacity: .4;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: translate3d(0, 0, 0);
+  z-index: 1;
+}
+
 .liftup-grid__image img {
   min-height: 100%;
   min-width: 100%;
-  opacity: 0.8;
 }
 
 /*

--- a/css/styles.css
+++ b/css/styles.css
@@ -5537,7 +5537,6 @@ a.liftup-grid__item:hover .liftup-grid__title {
 
 .liftup-grid__title {
   font-size: 1.875rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   text-align: center;
   text-transform: uppercase;
@@ -5557,7 +5556,6 @@ a.liftup-grid__item:hover .liftup-grid__title {
 
 .liftup-grid__ingress {
   font-size: 1.125rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   text-align: center;
 }

--- a/sass/components/_highlight.scss
+++ b/sass/components/_highlight.scss
@@ -36,7 +36,6 @@ a.highlight:hover {
 
 .highlight__title {
   @include font-size(80px, 48px);
-  @include text-shadow-overlay;
   color: $white;
   font-weight: 700;
   line-height: 1;
@@ -50,7 +49,6 @@ a.highlight:hover {
 
 .highlight__ingress {
   @include font-size(18px);
-  @include text-shadow-overlay;
   color: $white;
   max-width: 720px;
 }

--- a/sass/components/_highlight.scss
+++ b/sass/components/_highlight.scss
@@ -17,8 +17,10 @@
   @include breakpoint($small) {
     min-height: 480px;
   }
+}
 
-  &:hover .highlight__title{
+a.highlight:hover {
+  .highlight__title {
     text-decoration: underline;
   }
 }

--- a/sass/components/_highlight.scss
+++ b/sass/components/_highlight.scss
@@ -14,27 +14,12 @@
   padding-top: 30px;
   position: relative;
 
-  &:after {
-    background: black;
-    bottom: 0;
-    content: "";
-    left: 0;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    transform: translate3d(0,0,0);
-    transition-duration: 0.2s;
-    transition-property: opacity;
-    z-index: 1;
-  }
-
-  &:hover:after {
-    opacity: 0.2;
-  }
-
   @include breakpoint($small) {
     min-height: 480px;
+  }
+
+  &:hover .highlight__title{
+    text-decoration: underline;
   }
 }
 
@@ -69,7 +54,6 @@
 }
 
 .highlight__bgoverlay {
-  opacity: 0.7;
   position: absolute;
   left: 0;
   top: 0;
@@ -78,7 +62,16 @@
   background-position-x: 50%;
   background-size: cover;
 
-  @include breakpoint($small) {
-    opacity: 0.8;
+  &:after {
+    background-color: black;
+    bottom: 0;
+    content: "";
+    left: 0;
+    opacity: .4;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translate3d(0, 0, 0);
+    z-index: 1;
   }
 }

--- a/sass/components/_liftup-grid.scss
+++ b/sass/components/_liftup-grid.scss
@@ -26,10 +26,6 @@
   padding: 3em;
   position: relative;
 
-  &:hover .liftup-grid__title {
-    text-decoration: underline;
-  }
-
   @include breakpoint($small) {
     flex-basis: 34%;
     height: 33vw;
@@ -52,6 +48,12 @@
       margin: 0 auto;
       padding-right: 6em;
     }
+  }
+}
+
+a.liftup-grid__item:hover {
+  .liftup-grid__title {
+    text-decoration: underline;
   }
 }
 

--- a/sass/components/_liftup-grid.scss
+++ b/sass/components/_liftup-grid.scss
@@ -65,7 +65,6 @@ a.liftup-grid__item:hover {
 
 .liftup-grid__title {
   @include font-size(30px);
-  @include text-shadow-overlay;
   color: $white;
   text-align: center;
   text-transform: uppercase;
@@ -81,7 +80,6 @@ a.liftup-grid__item:hover {
 
 .liftup-grid__ingress {
   @include font-size(18px);
-  @include text-shadow-overlay;
   color: $white;
   text-align: center;
 

--- a/sass/components/_liftup-grid.scss
+++ b/sass/components/_liftup-grid.scss
@@ -26,30 +26,16 @@
   padding: 3em;
   position: relative;
 
+  &:hover .liftup-grid__title {
+    text-decoration: underline;
+  }
+
   @include breakpoint($small) {
     flex-basis: 34%;
     height: 33vw;
     max-height: 480px;
     padding: 3vw;
     width: 34%;
-  }
-
-  &:before {
-    background-color: #000;
-    bottom: 0;
-    content: "";
-    left: 0;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    transform: translate3d(0,0,0);
-    transition: opacity 0.2s;
-    z-index: 1;
-  }
-
-  &:hover:before {
-    opacity: 0.2;
   }
 
   &.theme-small {
@@ -115,9 +101,21 @@
   top: 0;
   z-index: 0;
 
+  &:after {
+    background-color: #000;
+    bottom: 0;
+    content: "";
+    left: 0;
+    opacity: .4;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translate3d(0, 0, 0);
+    z-index: 1;
+  }
+
   img {
     min-height: 100%;
     min-width: 100%;
-    opacity: 0.8;
   }
 }


### PR DESCRIPTION
## Description
- Makes following changes to “Highlight” and “Liftup grid” elements:
    * Element images have darker black overlay (previously was 20% and 40% on hover, now 40%). 
    * Elements with static color as background don’t get any overlay, not event on hover. (Previously was 20% on hover).
    * Element titles are underlined on hover.
    * Removes text shadow from element title and ingress.

## How to test
1. Run ```gulp serve``` in styleguide root directory.
2. Open http://localhost:3000/#section-18-1 and find “Liftup grid” elements.
3. Verify items with images have 40% black layer over them and it stays the same when hovered over.
4. Verify items without image don’t have any dark layer over them and it stays the same when hovered over.
5. Verify titles get underlined when hovered over the element.
6. Open and find “Highlight” elements http://localhost:3000/#section-19-1.
7. Repeat steps 4-6.

## Screenshots

![liftup_grid](https://user-images.githubusercontent.com/3032567/38241867-fb1cb030-373b-11e8-9c5a-83bd436db51e.jpg)

![liftup_grid_hover](https://user-images.githubusercontent.com/3032567/38241798-d6f33d14-373b-11e8-9afc-faef1e490044.jpg)

![highlight](https://user-images.githubusercontent.com/3032567/38241804-d9dd3c82-373b-11e8-8703-fa07d7d56fc0.jpg)

![highlight_hover](https://user-images.githubusercontent.com/3032567/38241788-d02fc8e4-373b-11e8-9046-fe55fe2a5e0e.jpg)


