### PR TITLE
Liftup mosaic visual improvements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5648,6 +5648,7 @@ a.liftup-grid__item:hover .liftup-grid__title {
   background-size: cover;
   background-position: center;
   height: 320px;
+  margin: 1px 0;
   padding: 2rem;
   position: relative;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -5672,11 +5672,12 @@ a.liftup-grid__item:hover .liftup-grid__title {
 @media (min-width: 48em) {
   .liftup-mosaic__item {
     height: 36vw;
+    margin: 1px;
     max-height: 480px;
-    width: 33.33%;
+    width: calc(33.33% - 2px);
   }
   .liftup-mosaic__item:nth-of-type(2) {
-    width: 66.66%;
+    width: calc(66.66% - 2px);
   }
   .liftup-mosaic__item:nth-of-type(2) .liftup-mosaic__title {
     font-size: 1.75rem;

--- a/css/styles.css
+++ b/css/styles.css
@@ -5657,17 +5657,16 @@ a.liftup-grid__item:hover .liftup-grid__title {
   bottom: 0;
   content: "";
   left: 0;
-  opacity: 0.2;
+  opacity: .4;
   position: absolute;
   right: 0;
   top: 0;
   transform: translate3d(0, 0, 0);
-  transition: opacity 0.2s;
   z-index: 1;
 }
 
-.liftup-mosaic__item:hover:before {
-  opacity: 0.4;
+.liftup-mosaic__item:hover .liftup-mosaic__title {
+  text-decoration: underline;
 }
 
 @media (min-width: 48em) {
@@ -5693,15 +5692,12 @@ a.liftup-grid__item:hover .liftup-grid__title {
   -moz-osx-font-smoothing: grayscale;
   vertical-align: bottom;
   content: "";
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   font-size: 2em;
   line-height: normal;
   position: absolute;
   right: 8px;
   top: 8px;
-  transition-duration: 0.2s;
-  transition-property: color;
   z-index: 1;
 }
 
@@ -5713,12 +5709,12 @@ a.liftup-grid__item:hover .liftup-grid__title {
   }
 }
 
-.liftup-mosaic__item.theme-video:hover:after {
-  color: #D2D2D2;
+.liftup-mosaic__item.theme-plain {
+  background-color: #000;
 }
 
-.liftup-mosaic__item.theme-plain {
-  background-color: #222;
+.liftup-mosaic__item.theme-plain:before {
+  opacity: 0;
 }
 
 .liftup-mosaic__label {
@@ -5729,7 +5725,6 @@ a.liftup-grid__item:hover .liftup-grid__title {
 }
 
 .liftup-mosaic__title {
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   font-size: 1.25rem;
   font-weight: 600;

--- a/sass/components/_liftup-mosaic.scss
+++ b/sass/components/_liftup-mosaic.scss
@@ -48,11 +48,12 @@
 
   @include breakpoint($small) {
     height: 36vw;
+    margin: 1px;
     max-height: 480px;
-    width: 33.33%;
+    width: calc(33.33% - 2px);
 
     &:nth-of-type(2) {
-      width: 66.66%;
+      width: calc(66.66% - 2px);
 
       .liftup-mosaic__title {
         @include font-size(28px);

--- a/sass/components/_liftup-mosaic.scss
+++ b/sass/components/_liftup-mosaic.scss
@@ -24,6 +24,7 @@
   background-size: cover;
   background-position: center;
   height: 320px;
+  margin: 1px 0;
   padding: 2rem;
   position: relative;
 

--- a/sass/components/_liftup-mosaic.scss
+++ b/sass/components/_liftup-mosaic.scss
@@ -32,17 +32,18 @@
     bottom: 0;
     content: "";
     left: 0;
-    opacity: 0.2;
+    opacity: .4;
     position: absolute;
     right: 0;
     top: 0;
     transform: translate3d(0,0,0);
-    transition: opacity 0.2s;
     z-index: 1;
   }
 
-  &:hover:before {
-    opacity: 0.4;
+  &:hover {
+    .liftup-mosaic__title {
+      text-decoration: underline;
+    }
   }
 
   @include breakpoint($small) {
@@ -62,15 +63,12 @@
   &.theme-video {
     &:after {
       @include icon($icon-video);
-      @include text-shadow-overlay;
       color: $white;
       font-size: 2em;
       line-height: normal;
       position: absolute;
       right: 8px;
       top: 8px;
-      transition-duration: 0.2s;
-      transition-property: color;
       z-index: 1;
 
       @include breakpoint($medium) {
@@ -79,16 +77,14 @@
         top: 16px;
       }
     }
-
-    &:hover {
-      &:after {
-        color: $mediumsilver;
-      }
-    }
   }
 
   &.theme-plain {
-    background-color: $black;
+    background-color: $pitchblack;
+
+    &:before {
+      opacity: 0;
+    }
   }
 }
 
@@ -100,7 +96,6 @@
 }
 
 .liftup-mosaic__title {
-  @include text-shadow-overlay;
   color: $white;
   font-size: 1.25rem;
   font-weight: 600;


### PR DESCRIPTION
## Description
Visual changes to “Liftup mosaic” element:
- Added space between mosaic items.
- Background color for items without image is now pitch black.
- Item titles are underlined when hovered over the item.
- Image overlay is now 40% black and same on hover.
- Removed text shadows from titles and play icons.

## How to test
1. Run ```gulp serve```.
2. Open http://localhost:3000/#section-18-3.
3. Verify you can see the changes described in the description/screenshots.

## Screenshots

![1](https://user-images.githubusercontent.com/3032567/38972948-1805f734-43ac-11e8-9008-a0a729a30d5a.jpg)

![2](https://user-images.githubusercontent.com/3032567/38973013-6820e260-43ac-11e8-8882-398f3c638307.jpg)
