### PR TITLE
Hero and video player visual improvements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4522,19 +4522,11 @@ dl, ol, ul {
   bottom: 0;
   content: "";
   left: 0;
-  opacity: 0.3;
+  opacity: .4;
   position: absolute;
   right: 0;
   top: 0;
-  transition-duration: 0.2s;
-  transition-property: opacity;
   z-index: 1;
-}
-
-@media (min-width: 48em) {
-  .hero-big:after {
-    opacity: 0.2;
-  }
 }
 
 .hero-big__top {
@@ -4552,7 +4544,6 @@ dl, ol, ul {
 
 .hero-big__title {
   font-size: 2.625rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   font-weight: 700;
   line-height: 1em;
@@ -4571,7 +4562,6 @@ dl, ol, ul {
   font-size: 1.125rem;
   font-weight: 600;
   font-style: normal;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   margin-bottom: 10px;
 }
@@ -4617,7 +4607,6 @@ dl, ol, ul {
 .hero-big__play {
   font-weight: 700;
   font-style: normal;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   -ms-flex-align: center;
       align-items: center;
   color: #FFF;
@@ -4728,7 +4717,6 @@ dl, ol, ul {
 
 .hero-big--centered .hero-big__link {
   font-size: 1.125rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   border: 2px solid #FFF;
   color: #FFF;
   display: inline-block;
@@ -4833,7 +4821,7 @@ dl, ol, ul {
   bottom: 0;
   content: "";
   left: 0;
-  opacity: 0.2;
+  opacity: .4;
   position: absolute;
   right: 0;
   top: 0;
@@ -4861,7 +4849,6 @@ dl, ol, ul {
   font-size: 3.125rem;
   font-weight: 700;
   font-style: normal;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   line-height: 1em;
   margin-bottom: 10px;
@@ -4872,7 +4859,6 @@ dl, ol, ul {
   font-size: 1.875rem;
   font-weight: 700;
   font-style: normal;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   line-height: 1.1em;
   margin-bottom: 10px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -8134,7 +8134,6 @@ input[type="text"].search-form-large__input {
 .video-player__play {
   font-weight: 700;
   font-style: normal;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   color: #FFF;
   text-transform: uppercase;
   z-index: 1;
@@ -8181,7 +8180,7 @@ input[type="text"].search-form-large__input {
   bottom: 0;
   content: "";
   left: 0;
-  opacity: 0.2;
+  opacity: .4;
   position: absolute;
   right: 0;
   top: 0;

--- a/sass/components/_hero.scss
+++ b/sass/components/_hero.scss
@@ -56,19 +56,11 @@
     bottom: 0;
     content: "";
     left: 0;
-    opacity: 0.3;
+    opacity: .4;
     position: absolute;
     right: 0;
     top: 0;
-    transition-duration: 0.2s;
-    transition-property: opacity;
     z-index: 1;
-  }
-
-  @include breakpoint($small) {
-    &:after {
-      opacity: 0.2;
-    }
   }
 }
 
@@ -87,7 +79,6 @@
 
 .hero-big__title {
   @include font-size(42px);
-  @include text-shadow-overlay;
   color: $white;
   font-weight: 700;
   line-height: 1em;
@@ -103,7 +94,6 @@
 .hero-big__ingress {
   @include font-size(18px);
   @include font-weight-medium;
-  @include text-shadow-overlay;
   color: $white;
   margin-bottom: 10px;
 
@@ -136,7 +126,6 @@
 
 .hero-big__play {
   @include font-weight-bold;
-  @include text-shadow-overlay;
   align-items: center;
   color: $white;
   display: flex;
@@ -225,7 +214,6 @@
 
   .hero-big__link {
     @include font-size(18px);
-    @include text-shadow-overlay;
     border: 2px solid $white;
     color: $white;
     display: inline-block;
@@ -319,7 +307,7 @@
     bottom: 0;
     content: "";
     left: 0;
-    opacity: 0.2;
+    opacity: .4;
     position: absolute;
     right: 0;
     top: 0;
@@ -347,7 +335,6 @@
 .hero-medium__title {
   @include font-size(50px);
   @include font-weight-bold;
-  @include text-shadow-overlay;
   color: $white;
   line-height: 1em;
   margin-bottom: 10px;
@@ -357,7 +344,6 @@
 .hero-medium__ingress {
   @include font-size(30px, 24px);
   @include font-weight-bold;
-  @include text-shadow-overlay;
   color: $white;
   line-height: 1.1em;
   margin-bottom: 10px;

--- a/sass/components/_video-player.scss
+++ b/sass/components/_video-player.scss
@@ -20,7 +20,6 @@
 
 .video-player__play {
   @include font-weight-bold;
-  @include text-shadow-overlay;
   color: $white;
   text-transform: uppercase;
   z-index: 1;
@@ -59,7 +58,7 @@
     bottom: 0;
     content: "";
     left: 0;
-    opacity: 0.2;
+    opacity: .4;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
## Description
Visual changes to “Hero big”, “Hero medium” and “Video player” elements:
- Changes overlay shown over image to be 40% black.
- Removes text shadows.

## How to test
1. Run ```gulp serve``` on styleguide root.
2. Open http://localhost:3000/#section-16-1-2. Verify “Hero big” element has styles described in description/screenshots.
3. Open http://localhost:3000/#section-16-1-4. Verify “Hero medium” element has styles described in description/screenshots.
4. Open http://localhost:3000/#section-21-1. Verify “Video player” element has styles described in description/screenshots.

## Screenshots

![1](https://user-images.githubusercontent.com/3032567/39032992-a88be620-4478-11e8-9ffe-0bbd5ed85d14.jpg)

![2](https://user-images.githubusercontent.com/3032567/39032996-aa6117ae-4478-11e8-8704-017c805d1143.jpg)

![3](https://user-images.githubusercontent.com/3032567/39032999-ac336438-4478-11e8-84d3-15571c6ad3d1.jpg)
