### PR TITLE
Footer copyright

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2766,6 +2766,8 @@ a.label:hover {
   .l-footer__copyright p {
     float: right;
     padding: 10px 0 0 20px;
+    text-align: left;
+    width: 24%;
   }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2765,10 +2765,7 @@ a.label:hover {
 @media (min-width: 48em) {
   .l-footer__copyright p {
     float: right;
-    margin-top: -50px;
-    padding: 0 0 16px 20px;
-    text-align: left;
-    width: 24%;
+    padding: 10px 0 16px 20px;
   }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2765,7 +2765,7 @@ a.label:hover {
 @media (min-width: 48em) {
   .l-footer__copyright p {
     float: right;
-    padding: 10px 0 16px 20px;
+    padding: 10px 0 0 20px;
   }
 }
 

--- a/sass/layouts/common/_l-footer.scss
+++ b/sass/layouts/common/_l-footer.scss
@@ -63,7 +63,7 @@
 
     @include breakpoint($small) {
       float: right;
-      padding: 10px 0 16px 20px;
+      padding: 10px 0 0 20px;
     }
   }
 }

--- a/sass/layouts/common/_l-footer.scss
+++ b/sass/layouts/common/_l-footer.scss
@@ -63,10 +63,7 @@
 
     @include breakpoint($small) {
       float: right;
-      margin-top: -50px;
-      padding: 0 0 16px 20px;
-      text-align: left;
-      width: 24%;
+      padding: 10px 0 16px 20px;
     }
   }
 }

--- a/sass/layouts/common/_l-footer.scss
+++ b/sass/layouts/common/_l-footer.scss
@@ -64,6 +64,8 @@
     @include breakpoint($small) {
       float: right;
       padding: 10px 0 0 20px;
+      text-align: left;
+      width: 24%;
     }
   }
 }


### PR DESCRIPTION
## Description
Currently footer copyright has some negative top margin. If the rightmost column in footer has the tallest content of all columns (eg. a list of links), then the copyright text will overlap it (see screenshots). Removing that negative margin and adjusting paddings, to make it work despite how tall content there is in the last footer column.

## How to test
1. Run ```gulp serve```.
2. Open http://localhost:3000/#section-15-2. Verify the footer looks like last screenshot.

## Screenshots

How footer copyright would be positioned with long content in the last footer column:

![1](https://user-images.githubusercontent.com/3032567/40472766-0dd67ede-5f43-11e8-93a9-cd106483a9ea.jpg)

How footer looks with markup provided by the styleguide:

![2](https://user-images.githubusercontent.com/3032567/40472768-10ac11be-5f43-11e8-97a5-054aca95ccf0.jpg)
