### PR TITLE
Make 'hero big' content wider

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4538,7 +4538,7 @@ dl, ol, ul {
 }
 
 .hero-big__content {
-  max-width: 40em;
+  max-width: 50em;
 }
 
 .hero-big__title {

--- a/sass/components/_hero.scss
+++ b/sass/components/_hero.scss
@@ -74,7 +74,7 @@
 }
 
 .hero-big__content {
-  max-width: 40em;
+  max-width: 50em;
 }
 
 .hero-big__title {


### PR DESCRIPTION
## Description
Makes content of "Hero big" element wider.

## How to test
1. Run ```gulp serve```.
2. Open http://localhost:3000/#section-16-1-2. Verify hero content is ```50em``` wide.