### PR TITLE
Underline active trail links in quick menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7208,7 +7208,7 @@ ul.pager > li.pager__page a {
   text-transform: uppercase;
 }
 
-.quick-menu a:hover:before, .quick-menu a.active:before {
+.quick-menu a:hover:before, .quick-menu a.active:before, .quick-menu a.active-trail:before {
   content: "";
   position: absolute;
   border-bottom: 2px solid #FFF;

--- a/sass/components/_quick-menu.scss
+++ b/sass/components/_quick-menu.scss
@@ -32,7 +32,8 @@
     text-transform: uppercase;
 
     &:hover,
-    &.active {
+    &.active,
+    &.active-trail {
       &:before {
         content: "";
         position: absolute;


### PR DESCRIPTION
## Description
Underlines active trail links in quick menu.

## How to test
1. Run ```gulp serve```.
2. Open http://localhost:3000/#section-15-1-2.
3. Alter the DOM by adding class ```active-trail``` to "Ajankohtaista" link. Verify it now looks the same as "Opiskelu" link.

## Screenshots

![1](https://user-images.githubusercontent.com/3032567/41699085-aaf04eb4-752a-11e8-8980-ea239ddc57fd.jpg)
