### PR TITLE
Allow header bar left to shrink

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2804,8 +2804,8 @@ a.label:hover {
 .l-header-bar__left {
   -ms-flex-positive: 1;
       flex-grow: 1;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  -ms-flex-negative: 1;
+      flex-shrink: 1;
   padding: 10px 0;
 }
 

--- a/sass/layouts/common/_l-header-bar.scss
+++ b/sass/layouts/common/_l-header-bar.scss
@@ -24,7 +24,7 @@
 
 .l-header-bar__left {
   flex-grow: 1;
-  flex-shrink: 0;
+  flex-shrink: 1;
   padding: 10px 0;
 
   @include breakpoint($medium) {


### PR DESCRIPTION
## Description
Allows left part of header bar to shrink.
If there's a long title after the logo on header bar on narrower display, the title is not allowed to shrink.

## Screenshots

![2](https://user-images.githubusercontent.com/3032567/43634220-3507269e-9714-11e8-9846-d6f6ba54433e.jpg)