### PR TITLE
Toggle element styles

### DIFF
--- a/sass/components/_main-menu.scss
+++ b/sass/components/_main-menu.scss
@@ -309,9 +309,13 @@ li.main-menu__front {
 }
 
 .main-menu-v2__expand {
+  background: none;
+  border: 0;
   bottom: 0;
   cursor: pointer;
   left: 0;
+  margin: 0;
+  padding: 0;
   position: absolute;
   text-align: center;
   top: 2px;

--- a/sass/components/_search-toggle.scss
+++ b/sass/components/_search-toggle.scss
@@ -1,6 +1,7 @@
 .search-toggle {
   align-items: center;
   background-color: transparent;
+  border: 0;
   color: $white;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
## Description
For accessibility reasons in helsinki.fi we are going to change some page elements from ```<span>``` to ```<button>```. For that reason we need to reset few styles of search toggle and main menu expand toggles. This has no visual effect if you use ```<span>``` elements.

## How to test
1. Run ```gulp serve```.
2. Open http://localhost:3000/#section-17-1 with viewport narrower than 1000px and compare it http://universityofhelsinki.github.io/Styleguide/#section-17-1. Verify both look the same (see screenshots).

## Screenshots

![2](https://user-images.githubusercontent.com/3032567/46347506-7195df00-c654-11e8-8274-89acd7ea709c.jpg)
