### PR TITLE
Ios link double tap bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Submit changes with pull requests.
 
 ### Dependencies ###
 
-1. node & npm
+1. node (version <= 8.4.0) & npm 
 2. gulp
 
 ### Setting up ###

--- a/css/styles.css
+++ b/css/styles.css
@@ -1997,10 +1997,10 @@ th {
 .button--small:focus, .accordion__title:focus,
 .button--accordion:focus,
 .button--action-before:focus,
-.button--action:focus, .button--anchor:focus, .button--expand:focus, .button--icon:focus, .button--outline:focus, input[type="submit"]:focus, .button--small:hover, .accordion__title:hover,
+.button--action:focus, .button--anchor:focus, .button--expand:focus, .button--icon:focus, .button--outline:focus, input:focus[type="submit"], .button--small:hover, .accordion__title:hover,
 .button--accordion:hover,
 .button--action-before:hover,
-.button--action:hover, .button--anchor:hover, .button--expand:hover, .button--icon:hover, .button--outline:hover, input[type="submit"]:hover,
+.button--action:hover, .button--anchor:hover, .button--expand:hover, .button--icon:hover, .button--outline:hover, input:hover[type="submit"],
 .button:focus,
 .button:hover {
   background-color: #005479;
@@ -2010,7 +2010,7 @@ th {
 .button--small:active, .accordion__title:active,
 .button--accordion:active,
 .button--action-before:active,
-.button--action:active, .button--anchor:active, .button--expand:active, .button--icon:active, .button--outline:active, input[type="submit"]:active, .is-active.button--small, .is-active.accordion__title,
+.button--action:active, .button--anchor:active, .button--expand:active, .button--icon:active, .button--outline:active, input:active[type="submit"], .is-active.button--small, .is-active.accordion__title,
 .is-active.button--accordion,
 .is-active.button--action-before,
 .is-active.button--action, .is-active.button--anchor, .is-active.button--expand, .is-active.button--icon, .is-active.button--outline, input.is-active[type="submit"],
@@ -2048,28 +2048,22 @@ th {
 .theme-transparent.button--small:hover, .theme-transparent.accordion__title:hover,
 .theme-transparent.button--accordion:hover,
 .theme-transparent.button--action-before:hover,
-.theme-transparent.button--action:hover, .theme-transparent.button--anchor:hover, .theme-transparent.button--expand:hover, .theme-transparent.button--icon:hover, .theme-transparent.button--outline:hover, input.theme-transparent[type="submit"]:hover, .theme-transparent-alt.button--small:hover, .theme-transparent-alt.accordion__title:hover,
+.theme-transparent.button--action:hover, .theme-transparent.button--anchor:hover, .theme-transparent.button--expand:hover, .theme-transparent.button--icon:hover, .theme-transparent.button--outline:hover, input.theme-transparent:hover[type="submit"], .theme-transparent-alt.button--small:hover, .theme-transparent-alt.accordion__title:hover,
 .theme-transparent-alt.button--accordion:hover,
 .theme-transparent-alt.button--action-before:hover,
-.theme-transparent-alt.button--action:hover, .theme-transparent-alt.button--anchor:hover, .theme-transparent-alt.button--expand:hover, .theme-transparent-alt.button--icon:hover, .theme-transparent-alt.button--outline:hover, input.theme-transparent-alt[type="submit"]:hover,
+.theme-transparent-alt.button--action:hover, .theme-transparent-alt.button--anchor:hover, .theme-transparent-alt.button--expand:hover, .theme-transparent-alt.button--icon:hover, .theme-transparent-alt.button--outline:hover, input.theme-transparent-alt:hover[type="submit"],
 .button.theme-transparent:hover,
 .button.theme-transparent-alt:hover {
   background-color: #0098d0;
 }
 
-.theme-transparent.button--small a:hover, .theme-transparent.accordion__title a:hover,
-.theme-transparent.button--accordion a:hover,
-.theme-transparent.button--action-before a:hover,
-.theme-transparent.button--action a:hover, .theme-transparent.button--anchor a:hover, .theme-transparent.button--expand a:hover, .theme-transparent.button--icon a:hover, .theme-transparent.button--outline a:hover, input.theme-transparent[type="submit"] a:hover, .theme-transparent.button--small:hover, .theme-transparent.accordion__title:hover,
+.theme-transparent.button--small a:hover, .theme-transparent.accordion__title a:hover, .theme-transparent.button--accordion a:hover, .theme-transparent.button--action-before a:hover, .theme-transparent.button--action a:hover, .theme-transparent.button--anchor a:hover, .theme-transparent.button--expand a:hover, .theme-transparent.button--icon a:hover, .theme-transparent.button--outline a:hover, input.theme-transparent[type="submit"] a:hover, .theme-transparent.button--small:hover, .theme-transparent.accordion__title:hover,
 .theme-transparent.button--accordion:hover,
 .theme-transparent.button--action-before:hover,
-.theme-transparent.button--action:hover, .theme-transparent.button--anchor:hover, .theme-transparent.button--expand:hover, .theme-transparent.button--icon:hover, .theme-transparent.button--outline:hover, input.theme-transparent[type="submit"]:hover, .theme-transparent-alt.button--small a:hover, .theme-transparent-alt.accordion__title a:hover,
-.theme-transparent-alt.button--accordion a:hover,
-.theme-transparent-alt.button--action-before a:hover,
-.theme-transparent-alt.button--action a:hover, .theme-transparent-alt.button--anchor a:hover, .theme-transparent-alt.button--expand a:hover, .theme-transparent-alt.button--icon a:hover, .theme-transparent-alt.button--outline a:hover, input.theme-transparent-alt[type="submit"] a:hover, .theme-transparent-alt.button--small:hover, .theme-transparent-alt.accordion__title:hover,
+.theme-transparent.button--action:hover, .theme-transparent.button--anchor:hover, .theme-transparent.button--expand:hover, .theme-transparent.button--icon:hover, .theme-transparent.button--outline:hover, input.theme-transparent:hover[type="submit"], .theme-transparent-alt.button--small a:hover, .theme-transparent-alt.accordion__title a:hover, .theme-transparent-alt.button--accordion a:hover, .theme-transparent-alt.button--action-before a:hover, .theme-transparent-alt.button--action a:hover, .theme-transparent-alt.button--anchor a:hover, .theme-transparent-alt.button--expand a:hover, .theme-transparent-alt.button--icon a:hover, .theme-transparent-alt.button--outline a:hover, input.theme-transparent-alt[type="submit"] a:hover, .theme-transparent-alt.button--small:hover, .theme-transparent-alt.accordion__title:hover,
 .theme-transparent-alt.button--accordion:hover,
 .theme-transparent-alt.button--action-before:hover,
-.theme-transparent-alt.button--action:hover, .theme-transparent-alt.button--anchor:hover, .theme-transparent-alt.button--expand:hover, .theme-transparent-alt.button--icon:hover, .theme-transparent-alt.button--outline:hover, input.theme-transparent-alt[type="submit"]:hover,
+.theme-transparent-alt.button--action:hover, .theme-transparent-alt.button--anchor:hover, .theme-transparent-alt.button--expand:hover, .theme-transparent-alt.button--icon:hover, .theme-transparent-alt.button--outline:hover, input.theme-transparent-alt:hover[type="submit"],
 .button.theme-transparent a:hover,
 .button.theme-transparent:hover,
 .button.theme-transparent-alt a:hover,
@@ -2243,11 +2237,9 @@ a:hover .accordion__title:before, .accordion__title:hover:before, a:hover
   background-color: transparent;
 }
 
-
 .theme-transparent.button--action-before a:hover,
 .theme-transparent.button--action-before:hover,
-.theme-transparent.button--action-before:hover:after,
-.theme-transparent-alt.button--action-before a:hover,
+.theme-transparent.button--action-before:hover:after, .theme-transparent-alt.button--action-before a:hover,
 .theme-transparent-alt.button--action-before:hover,
 .theme-transparent-alt.button--action-before:hover:after,
 .button--action.theme-transparent a:hover,
@@ -3304,6 +3296,16 @@ a:hover {
 }
 
 /*
+  Disable pseudo elements on hover on devices that don't support it.
+  This fixes link double tap issue on iOS devices.
+*/
+@media (hover: none) {
+  a:hover::before, a:hover::after {
+    display: none;
+  }
+}
+
+/*
   section: 3.4
   title: Blockquote
 */
@@ -4020,7 +4022,7 @@ dl, ol, ul {
 }
 
 .carousel-unwrapped__direction-nav a.carousel-unwrapped__prev {
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.1), transparent 100%);
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0) 100%);
   left: 0;
 }
 
@@ -4036,7 +4038,7 @@ dl, ol, ul {
 }
 
 .carousel-unwrapped__direction-nav a.carousel-unwrapped__next {
-  background-image: linear-gradient(to left, rgba(0, 0, 0, 0.1), transparent 100%);
+  background-image: linear-gradient(to left, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0) 100%);
   right: 0;
 }
 
@@ -6536,9 +6538,13 @@ span.links__link.theme-language {
 }
 
 .main-menu-v2__expand {
+  background: none;
+  border: 0;
   bottom: 0;
   cursor: pointer;
   left: 0;
+  margin: 0;
+  padding: 0;
   position: absolute;
   text-align: center;
   top: 2px;
@@ -7564,6 +7570,7 @@ input[type="text"].search-form-large__input {
   -ms-flex-align: center;
       align-items: center;
   background-color: transparent;
+  border: 0;
   color: #FFF;
   cursor: pointer;
   display: -ms-flexbox;
@@ -7726,7 +7733,8 @@ input[type="text"].search-form-large__input {
  template: 6_1_2_table-simple
  description:
 */
-.textarea table, .textarea-ingress table, .box-application__table,
+.textarea table,
+.textarea-ingress table, .box-application__table,
 .table-simple {
   font-size: 0.875rem;
 }
@@ -7938,25 +7946,31 @@ input[type="text"].search-form-large__input {
   line-height: 1.5em;
 }
 
-.textarea ul, .textarea ol, .textarea-ingress ul, .textarea-ingress ol {
+.textarea ul, .textarea ol,
+.textarea-ingress ul,
+.textarea-ingress ol {
   margin-bottom: 30px;
 }
 
-.textarea li, .textarea-ingress li {
+.textarea li,
+.textarea-ingress li {
   line-height: 1.5em;
   margin-bottom: 0.5em;
 }
 
-.textarea ul, .textarea-ingress ul {
+.textarea ul,
+.textarea-ingress ul {
   padding-left: 2em;
   position: relative;
 }
 
-.textarea ul li, .textarea-ingress ul li {
+.textarea ul li,
+.textarea-ingress ul li {
   list-style-type: none;
 }
 
-.textarea ul li:before, .textarea-ingress ul li:before {
+.textarea ul li:before,
+.textarea-ingress ul li:before {
   font-size: 0.5625rem;
   display: inline-block;
   font-family: "hy-icons";
@@ -7971,17 +7985,20 @@ input[type="text"].search-form-large__input {
   position: absolute;
 }
 
-.textarea ol, .textarea-ingress ol {
+.textarea ol,
+.textarea-ingress ol {
   counter-reset: item;
   padding-left: 2em;
   position: relative;
 }
 
-.textarea ol li, .textarea-ingress ol li {
+.textarea ol li,
+.textarea-ingress ol li {
   display: block;
 }
 
-.textarea ol li:before, .textarea-ingress ol li:before {
+.textarea ol li:before,
+.textarea-ingress ol li:before {
   font-family: 'Open Sans', Helvetica, Arial, sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -7991,25 +8008,46 @@ input[type="text"].search-form-large__input {
   position: absolute;
 }
 
-.textarea h1, .textarea h2, .textarea h3, .textarea h4, .textarea legend, .textarea .logo-block__content .logo-block__sitename, .logo-block__content .textarea .logo-block__sitename, .textarea h5, .textarea h6, .textarea-ingress h1, .textarea-ingress h2, .textarea-ingress h3, .textarea-ingress h4, .textarea-ingress legend, .textarea-ingress .logo-block__content .logo-block__sitename, .logo-block__content .textarea-ingress .logo-block__sitename, .textarea-ingress h5, .textarea-ingress h6 {
+.textarea h1, .textarea h2, .textarea h3, .textarea h4, .textarea legend, .textarea .logo-block__content .logo-block__sitename, .logo-block__content .textarea .logo-block__sitename, .textarea h5, .textarea h6,
+.textarea-ingress h1,
+.textarea-ingress h2,
+.textarea-ingress h3,
+.textarea-ingress h4,
+.textarea-ingress legend,
+.textarea-ingress .logo-block__content .logo-block__sitename,
+.logo-block__content .textarea-ingress .logo-block__sitename,
+.textarea-ingress h5,
+.textarea-ingress h6 {
   margin-top: 32px;
 }
 
-.textarea h1:first-child, .textarea h2:first-child, .textarea h3:first-child, .textarea h4:first-child, .textarea legend:first-child, .textarea .logo-block__content .logo-block__sitename:first-child, .logo-block__content .textarea .logo-block__sitename:first-child, .textarea h5:first-child, .textarea h6:first-child, .textarea-ingress h1:first-child, .textarea-ingress h2:first-child, .textarea-ingress h3:first-child, .textarea-ingress h4:first-child, .textarea-ingress legend:first-child, .textarea-ingress .logo-block__content .logo-block__sitename:first-child, .logo-block__content .textarea-ingress .logo-block__sitename:first-child, .textarea-ingress h5:first-child, .textarea-ingress h6:first-child {
+.textarea h1:first-child, .textarea h2:first-child, .textarea h3:first-child, .textarea h4:first-child, .textarea legend:first-child, .textarea .logo-block__content .logo-block__sitename:first-child, .logo-block__content .textarea .logo-block__sitename:first-child, .textarea h5:first-child, .textarea h6:first-child,
+.textarea-ingress h1:first-child,
+.textarea-ingress h2:first-child,
+.textarea-ingress h3:first-child,
+.textarea-ingress h4:first-child,
+.textarea-ingress legend:first-child,
+.textarea-ingress .logo-block__content .logo-block__sitename:first-child,
+.logo-block__content .textarea-ingress .logo-block__sitename:first-child,
+.textarea-ingress h5:first-child,
+.textarea-ingress h6:first-child {
   margin-top: 0;
 }
 
-.textarea a, .textarea-ingress a {
+.textarea a,
+.textarea-ingress a {
   word-wrap: break-word;
 }
 
-.textarea table, .textarea-ingress table {
+.textarea table,
+.textarea-ingress table {
   line-height: normal;
   margin-bottom: 2em;
 }
 
 @media (min-width: 48em) {
-  .textarea .dropcap, .textarea-ingress .dropcap {
+  .textarea .dropcap,
+  .textarea-ingress .dropcap {
     font-size: 4.6875rem;
     font-weight: 700;
     font-style: normal;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "description": "Living styleguide for University of Helsinki",
   "author": "Benjamin Horn <benjamin.horn@idean.com>",
   "license": "ISC",
+  "engines": {
+    "node": "<= 8.4.0"
+  },
   "devDependencies": {
     "breakpoint-sass": "^2.7.0",
     "browser-sync": "^2.18.2",

--- a/sass/common-elements/_common-elements.scss
+++ b/sass/common-elements/_common-elements.scss
@@ -121,6 +121,19 @@ a {
 }
 
 /*
+  Disable pseudo elements on hover on devices that don't support it.
+  This fixes link double tap issue on iOS devices.
+*/
+@media (hover: none) {
+  a:hover {
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+}
+
+/*
   section: 3.4
   title: Blockquote
 */


### PR DESCRIPTION
- Added media rule to disable pseudo elements on a elements on hover to fix link double tap issue on iOS devices. 
- Added node version note to readme

How to test:
Use iOS device (for example from BrowserStack) and go to the styleguide: http://localhost:3000/#section-15-1-2

- Before fix: Tapping navigation link (for.ex. 'Tutkimus') added underline under the link which resulted having two active looking menus ('Tutkimus' and 'Opiskelu) and the second tap on 'Tutkimus' scrolls the window to the top.
- After fix: clicking 'Tutkimus' on iOS device works as on chrome for. ex. and scrolls the window to the top 

Note: Due the fact that the navigation menu is hidden on the mentioned page when viewport is not wide enough, tilted iPad is the best device to test this on Styleguide site 