### PR TITLE
Fix footer title style

### DIFF
--- a/templates/15_2_footer.html
+++ b/templates/15_2_footer.html
@@ -6,7 +6,7 @@
                     <a class="logo theme-big" href="/fi"></a>
                 </div>
                 <div class="logo-block__content">
-                    <h4>Hel­sin­gin yli­opis­to</h4>
+                    <div class="logo-block__sitename">Hel­sin­gin yli­opis­to</div>
                     <p>PL 3 (Fabianinkatu 33)<br>
                         00014 Helsingin yliopisto</p>
                     <p>Puhelinvaihde: <a class="is-tel" href="tel:+3582941911">02941 911</a></p>


### PR DESCRIPTION
This is broken in templates, h4 is now dark gray text on black background.  "logo-block__sitename" is probably the intended style here. At least it looks correct.